### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-to-gpr.yml
+++ b/.github/workflows/publish-to-gpr.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Build, Tag, Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/${{ github.repository }}/hakyll-latex
         registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore